### PR TITLE
Turned pall back to just return instead of assigning global = -1 sinc…

### DIFF
--- a/functions1.c
+++ b/functions1.c
@@ -46,10 +46,7 @@ void pall(stack_t **stack, unsigned int line_number)
 
 	(void)line_number;
 	if (*stack == NULL || stack == NULL)
-	{
-		global = -1;
 		return;
-	}
 	current = *stack;
 	while (current)
 	{


### PR DESCRIPTION
…e that was making it exit with exit failure instead of finishing main and returning 0